### PR TITLE
When FreeBSD, certain ints need to be unsigned

### DIFF
--- a/sds.c
+++ b/sds.c
@@ -36,6 +36,19 @@
 
 #include "sds.h"
 
+/* 
+ * FreeBSD's libc often uses unsigned ints where glibc doesn't. size_t,
+ * return of strlen, etc.
+ */
+#ifdef __FreeBSD__
+typedef unsigned int INT;
+#endif
+#else
+typedef int INT;
+#endif
+/* TODO: Expand tests for other BSDs as they may share this difference. */
+
+
 /* Create a new sds string with the content specified by the 'init' pointer
  * and 'initlen'.
  * If NULL is used for 'init' the string is initialized with zero bytes.
@@ -104,7 +117,7 @@ void sdsfree(sds s) {
  * remains 6 bytes. */
 void sdsupdatelen(sds s) {
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
-    int reallen = strlen(s);
+    INT reallen = strlen(s);
     sh->free += (sh->len-reallen);
     sh->len = reallen;
 }
@@ -197,7 +210,7 @@ size_t sdsAllocSize(sds s) {
  * ... check for nread <= 0 and handle it ...
  * sdsIncrLen(s, nread);
  */
-void sdsIncrLen(sds s, int incr) {
+void sdsIncrLen(sds s, INT incr) {
     struct sdshdr *sh = (void*) (s-sizeof *sh);;
 
     assert(sh->free >= incr);

--- a/sds.h
+++ b/sds.h
@@ -32,14 +32,13 @@
 #define __SDS_H
 
 #define SDS_MAX_PREALLOC (1024*1024)
-
 #include <sys/types.h>
 #include <stdarg.h>
 
 typedef char *sds;
 
 struct sdshdr {
-    int len;
+    INT len;
     int free;
     char buf[];
 };
@@ -94,7 +93,7 @@ sds sdsjoinsds(sds *argv, int argc, const char *sep, size_t seplen);
 
 /* Low level functions exposed to the user API */
 sds sdsMakeRoomFor(sds s, size_t addlen);
-void sdsIncrLen(sds s, int incr);
+void sdsIncrLen(sds s, INT incr);
 sds sdsRemoveFreeSpace(sds s);
 size_t sdsAllocSize(sds s);
 


### PR DESCRIPTION
Hi Chris,

Since the author isnt updating the original repo any more, I thought
I'd send the request here:

On FreeBSD's libc, certain ints are unsigned, such as size_t and the
return of strlen(). This push defines type INT, which is an unsigned int on
FreeBSD and a signed int everywhere else. With the relevant vars
changed, this fixes sds on FreeBSD systems.
